### PR TITLE
Add note on installing over ssh

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,8 @@
 # Troubleshooting
 
+### Issues installing electron-prebuilt
+You must run `npm install` when logged into the GUI and not over ssh as electron-prebuilt will not install outside of the GUI.
+
 ### Microphone and Speech Recognition issues
 Most of these issues can be fixed by following the following:
 


### PR DESCRIPTION
This might be obvious I wasted more time than I should have trying to work out why electron-prebuilt wouldn't install when I was logged into my pi over ssh. Installing in the GUI worked perfectly first time.
